### PR TITLE
Fix login API and CORS

### DIFF
--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,7 +1,7 @@
 <?php
 // 允許來自 http://localhost:3000 的跨來源請求
 header("Access-Control-Allow-Origin: http://localhost:3000");
-header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
+header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, Auth");
 header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS");
 header("Access-Control-Allow-Credentials: true");
 

--- a/front/src/components/LoginModal.js
+++ b/front/src/components/LoginModal.js
@@ -4,6 +4,7 @@ import { Modal, Form, Input, Button, message, Divider } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import Request from '../utils/Request';
 import { setToken } from '../utils/auth';
+import { getApiUrl } from '../config';
 
 const LoginModal = ({ visible, onCancel, onSuccess }) => {
   const [form] = Form.useForm();
@@ -17,7 +18,7 @@ const LoginModal = ({ visible, onCancel, onSuccess }) => {
     };
 
     try {
-      const res = await Request().post('?action=doLogin', Qs.stringify(postData));
+      const res = await Request().post(getApiUrl('doLogin'), Qs.stringify(postData));
       const response = res.data;
 
       if (response.status === 200) {

--- a/front/src/utils/Request.js
+++ b/front/src/utils/Request.js
@@ -10,12 +10,17 @@ import { API_CONFIG } from '../config';
 const Request = () => {
   const token = getToken();
 
+  const headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+
+  if (token) {
+    headers.Auth = token;
+  }
+
   const instance = axios.create({
     baseURL: API_CONFIG.baseURL,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Auth: token || '',
-    },
+    headers,
   });
 
   return instance;


### PR DESCRIPTION
## Summary
- allow `Auth` header for CORS
- call login API using `getApiUrl`

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6846e674e730832f8cb299193b1be8ce